### PR TITLE
Handle multi-lot expiries in peremption and stats views

### DIFF
--- a/web/app/peremption/views.py
+++ b/web/app/peremption/views.py
@@ -6,8 +6,10 @@ from typing import Dict, Any, List, Optional
 from flask import Blueprint, render_template, request, jsonify, abort
 from flask_login import login_required, current_user
 
+from sqlalchemy.exc import ProgrammingError, OperationalError
+
 # ⚠️ IMPORTANT : pas d'import de "db" depuis app/__init__.py pour éviter le circular import
-from ..models import StockNode, NodeType, Role
+from ..models import StockNode, StockItemExpiry, NodeType, Role
 
 bp_peremption = Blueprint("peremption", __name__)
 
@@ -29,8 +31,18 @@ def _build_path(n: StockNode) -> str:
     parts.reverse()
     return " › ".join(parts) if parts else "—"
 
-def _row(n: StockNode, today: date) -> Dict[str, Any]:
-    exp = n.expiry_date  # peut être None
+def _row(
+    n: StockNode,
+    today: date,
+    expiry: Optional[date],
+    *,
+    lot: Optional[str] = None,
+    lot_quantity: Optional[int] = None,
+    note: Optional[str] = None,
+    entry_id: Optional[int] = None,
+    source: str = "legacy",
+) -> Dict[str, Any]:
+    exp = expiry
     days_left: Optional[int] = None
     if exp is not None:
         days_left = (exp - today).days
@@ -43,13 +55,18 @@ def _row(n: StockNode, today: date) -> Dict[str, Any]:
         else:
             status = "OK"
     return {
-        "id": n.id,
+        "id": entry_id or n.id,
+        "item_id": n.id,
         "name": n.name,
         "quantity": n.quantity,
         "expiry_date": exp.isoformat() if exp else None,
         "days_left": days_left,
         "status": status,  # EXPIRED / SOON / OK
         "path": _build_path(n),
+        "lot": lot,
+        "lot_quantity": lot_quantity,
+        "note": note,
+        "source": source,
     }
 
 # ---------------- Routes ----------------
@@ -77,16 +94,65 @@ def peremption_api():
     today = date.today()
     limit = today + timedelta(days=days)
 
-    # Tous les items (ITEM) avec une date de péremption <= limit
-    q = (
+    items: List[Dict[str, Any]] = []
+
+    # On tente d'utiliser la table des lots multiples si disponible
+    item_ids_with_lots: set[int] = set()
+    try:
+        rows: List[StockItemExpiry] = (
+            StockItemExpiry.query
+            .join(StockNode, StockNode.id == StockItemExpiry.node_id)
+            .filter(StockNode.type == NodeType.ITEM)
+            .filter(StockItemExpiry.expiry_date <= limit)
+            .order_by(
+                StockItemExpiry.expiry_date.asc(),
+                StockNode.name.asc(),
+                StockItemExpiry.id.asc(),
+            )
+            .all()
+        )
+        for row in rows:
+            item = row.item
+            if not item:
+                continue
+            item_ids_with_lots.add(item.id)
+            items.append(
+                _row(
+                    item,
+                    today,
+                    row.expiry_date,
+                    lot=row.lot,
+                    lot_quantity=row.quantity,
+                    note=row.note,
+                    entry_id=row.id,
+                    source="lot",
+                )
+            )
+    except (ProgrammingError, OperationalError):
+        # Table absente → rollback et fallback legacy
+        StockItemExpiry.query.session.rollback()
+    except Exception:
+        # Autre erreur → rollback et on retombe sur le legacy
+        StockItemExpiry.query.session.rollback()
+
+    # Fallback : anciennes données (colonne unique sur StockNode)
+    legacy_q = (
         StockNode.query
         .filter(StockNode.type == NodeType.ITEM)
         .filter(StockNode.expiry_date.isnot(None))
         .filter(StockNode.expiry_date <= limit)
         .order_by(StockNode.expiry_date.asc(), StockNode.name.asc())
     )
+    for node in legacy_q.all():
+        if node.id in item_ids_with_lots:
+            continue
+        items.append(_row(node, today, node.expiry_date, source="legacy"))
 
-    items: List[Dict[str, Any]] = [_row(n, today) for n in q.all()]
+    items.sort(key=lambda it: (
+        it.get("expiry_date") is None,
+        it.get("expiry_date") or "",
+        (it.get("path") or "") + " " + (it.get("name") or "")
+    ))
 
     return jsonify({
         "count": len(items),

--- a/web/app/stats/views.py
+++ b/web/app/stats/views.py
@@ -1,14 +1,16 @@
 # app/stats/views.py — Endpoints de statistiques d'événement + péremptions
 from __future__ import annotations
 from datetime import date
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 
 from flask import Blueprint, jsonify
 from flask_login import login_required, current_user
 
 from .. import db
-from ..models import Role, StockNode, NodeType
+from ..models import Role, StockNode, StockItemExpiry, NodeType
 from ..reports.utils import compute_summary, build_event_tree, latest_verifications
+
+from sqlalchemy.exc import ProgrammingError, OperationalError
 
 bp = Blueprint("stats", __name__)
 
@@ -80,6 +82,30 @@ def _serialize_item(n: StockNode) -> Dict[str, Any]:
         "parent_id": n.parent_id,
     }
 
+
+def _expiries_by_item() -> Dict[int, List[StockItemExpiry]]:
+    try:
+        rows: List[StockItemExpiry] = (
+            StockItemExpiry.query
+            .order_by(
+                StockItemExpiry.node_id.asc(),
+                StockItemExpiry.expiry_date.asc(),
+                StockItemExpiry.id.asc(),
+            )
+            .all()
+        )
+    except (ProgrammingError, OperationalError):
+        StockItemExpiry.query.session.rollback()
+        return {}
+    except Exception:
+        StockItemExpiry.query.session.rollback()
+        return {}
+
+    mapping: Dict[int, List[StockItemExpiry]] = {}
+    for row in rows:
+        mapping.setdefault(row.node_id, []).append(row)
+    return mapping
+
 @bp.get("/stock/expiry")
 @login_required
 def stock_expiry_list():
@@ -103,10 +129,37 @@ def stock_expiry_list():
         # garder même ceux sans date (pour "no_date")
     )
 
+    expiries_map = _expiries_by_item()
+
     buckets: Dict[str, List[Dict[str, Any]]] = {"expired": [], "j30": [], "j60": [], "later": [], "no_date": []}
     for n in q.all():
-        cat = _classify_expiry(getattr(n, "expiry_date", None), today)
-        buckets[cat].append(_serialize_item(n))
+        entries = []
+        closest: Optional[date] = None
+        for entry in expiries_map.get(n.id, []):
+            delta = (entry.expiry_date - today).days
+            entries.append(
+                {
+                    "id": entry.id,
+                    "expiry_date": entry.expiry_date.isoformat(),
+                    "quantity": entry.quantity,
+                    "lot": entry.lot,
+                    "note": entry.note,
+                    "days_left": delta,
+                    "status": _classify_expiry(entry.expiry_date, today),
+                }
+            )
+            if closest is None or entry.expiry_date < closest:
+                closest = entry.expiry_date
+
+        fallback_date = getattr(n, "expiry_date", None)
+        effective_date = closest or fallback_date
+        cat = _classify_expiry(effective_date, today)
+        payload = _serialize_item(n)
+        payload["expiry_date"] = effective_date.isoformat() if effective_date else None
+        if entries:
+            payload["expiries"] = entries
+            payload["next_expiry"] = entries[0]
+        buckets[cat].append(payload)
 
     # Tri par date (quand présente), puis par nom
     def sort_key(it: Dict[str, Any]):
@@ -131,9 +184,17 @@ def stock_expiry_counts():
         .filter(StockNode.type == NodeType.ITEM)
     )
 
+    expiries_map = _expiries_by_item()
+
     counts = {"expired": 0, "j30": 0, "j60": 0, "later": 0, "no_date": 0}
     for n in q.all():
-        cat = _classify_expiry(getattr(n, "expiry_date", None), today)
+        closest: Optional[date] = None
+        for entry in expiries_map.get(n.id, []):
+            if closest is None or entry.expiry_date < closest:
+                closest = entry.expiry_date
+        fallback_date = getattr(n, "expiry_date", None)
+        effective_date = closest or fallback_date
+        cat = _classify_expiry(effective_date, today)
         counts[cat] += 1
 
     return jsonify({"today": today.isoformat(), **counts})

--- a/web/app/templates/peremption.html
+++ b/web/app/templates/peremption.html
@@ -37,7 +37,7 @@
   .badge-ok{background:#0e2a24;color:#bff3e7;border-color:#1d6e5d}
 
   .muted{color:#9fb0c6}
-  .qty{opacity:.9;font-size:12px;border:1px dashed var(--border);border-radius:8px;padding:2px 8px;margin-left:6px}
+  .details{opacity:.85;font-size:12px;margin-top:4px}
   .search{flex:1}
   @media (max-width: 820px){
     .row{grid-template-columns: 1fr 140px 100px;gap:8px}
@@ -114,10 +114,16 @@ function renderRows(items){
     if(q && !hay.includes(q)) continue;
 
     const cls = it.status==="EXPIRED" ? "expired" : (it.status==="SOON" ? "soon" : "ok");
+    const metaParts = [];
+    if(it.quantity != null) metaParts.push(`Qté cible : ${it.quantity}`);
+    if(it.lot_quantity != null) metaParts.push(`Qté lot : ${it.lot_quantity}`);
+    if(it.lot) metaParts.push(`Lot ${it.lot}`);
+    if(it.note) metaParts.push(it.note);
+
     const row = el("div",{class:"row "+cls},
       el("div", null,
         el("div",{class:"strong"}, it.name),
-        el("div",{class:"muted"}, "Qté : ", (it.quantity!=null?it.quantity:1))
+        metaParts.length ? el("div",{class:"muted details"}, metaParts.join(" • ")) : el("div",{class:"muted"}, "Qté cible : ", (it.quantity!=null?it.quantity:"—"))
       ),
       el("div",{class:"col-path muted"}, it.path || "—"),
       el("div",{class:"col-date"}, fmtDate(it.expiry_date)),
@@ -137,7 +143,7 @@ async function loadData(){
   if(!r.ok){ document.getElementById("summary").textContent = "Erreur de chargement"; return; }
   const data = await r.json();
   const items = data.items || [];
-  document.getElementById("summary").textContent = `${items.length} article(s) • fenêtre ${data.window_days} j`;
+  document.getElementById("summary").textContent = `${items.length} entrée(s) • fenêtre ${data.window_days} j`;
   renderRows(items);
 }
 


### PR DESCRIPTION
## Summary
- expose StockItemExpiry lots in the peremption API with graceful fallbacks
- aggregate multi-lot expiries in the stats endpoints while keeping legacy compatibility
- surface lot metadata in the peremption UI so operators see lot numbers and notes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dec0699cec8331bd0c33c39e898dcc