### PR TITLE
Ensure legacy databases expose unique stock columns

### DIFF
--- a/web/app/__init__.py
+++ b/web/app/__init__.py
@@ -51,6 +51,12 @@ def create_app() -> Flask:
     # Init extensions
     db.init_app(app)
     migrate.init_app(app, db)
+    try:
+        from .schema_compat import ensure_schema_compatibility
+        with app.app_context():
+            ensure_schema_compatibility()
+    except Exception as exc:
+        app.logger.warning("Unable to ensure schema compatibility: %s", exc)
     login_manager.init_app(app)
     login_manager.login_view = "auth.login"
     try:

--- a/web/app/models.py
+++ b/web/app/models.py
@@ -96,6 +96,10 @@ class StockNode(db.Model):
     # Quantité cible pour les ITEMS uniquement
     quantity = db.Column(db.Integer, nullable=True)
 
+    # Un parent peut être marqué comme "objet unique" (pas d'enfants, mais quantité max)
+    unique_item = db.Column(db.Boolean, nullable=False, default=False)
+    unique_quantity = db.Column(db.Integer, nullable=True)
+
     # (Legacy) Date de péremption simple. Gardée pour compatibilité ascendante.
     # Désormais on utilise StockItemExpiry pour plusieurs dates.
     expiry_date = db.Column(db.Date, nullable=True)
@@ -111,6 +115,10 @@ class StockNode(db.Model):
     __table_args__ = (
         CheckConstraint("level >= 0 AND level <= 5", name="ck_stocknode_level_0_5"),
         CheckConstraint("(quantity IS NULL) OR (quantity >= 0)", name="ck_stocknode_qty_nonneg"),
+        CheckConstraint(
+            "(unique_quantity IS NULL) OR (unique_quantity >= 0)",
+            name="ck_stocknode_unique_qty_nonneg",
+        ),
     )
 
     def is_leaf(self) -> bool:
@@ -137,6 +145,7 @@ event_stock = db.Table(
     "event_stock",
     db.Column("event_id", db.Integer, db.ForeignKey("events.id"), primary_key=True),
     db.Column("node_id", db.Integer, db.ForeignKey("stock_nodes.id"), primary_key=True),
+    db.Column("selected_quantity", db.Integer, nullable=True),
 )
 
 # -------------------------------------------------------------------

--- a/web/app/schema_compat.py
+++ b/web/app/schema_compat.py
@@ -1,0 +1,81 @@
+"""Utilities to keep backward compatibility with older database schemas."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterable
+
+from sqlalchemy import inspect, text
+from sqlalchemy.engine import Connection
+from sqlalchemy.exc import ProgrammingError, OperationalError
+from flask import current_app
+
+from . import db
+
+
+@contextmanager
+def _connection() -> Iterable[Connection]:
+    """Return a connection bound to the current Flask-SQLAlchemy engine."""
+    engine = db.engine
+    with engine.begin() as conn:
+        yield conn
+
+
+def ensure_schema_compatibility() -> None:
+    """Ensure columns introduced after the initial schema exist.
+
+    The production database that ships with the appliance might predate the
+    ``unique_item`` / ``unique_quantity`` fields as well as the
+    ``event_stock.selected_quantity`` column.  When running against such a
+    database we add the columns on the fly so that the application can start
+    without requiring a manual Alembic migration.
+    """
+
+    with _connection() as conn:
+        inspector = inspect(conn)
+        tables = set(inspector.get_table_names())
+
+        if "stock_nodes" in tables:
+            _ensure_stock_nodes_columns(conn, inspector)
+
+        if "event_stock" in tables:
+            _ensure_event_stock_columns(conn, inspector)
+
+
+def _ensure_stock_nodes_columns(conn: Connection, inspector) -> None:
+    columns = {col["name"] for col in inspector.get_columns("stock_nodes")}
+
+    if "unique_item" not in columns:
+        current_app.logger.info("Adding column stock_nodes.unique_item")
+        _execute_ignore_duplicate(
+            conn,
+            "ALTER TABLE stock_nodes ADD COLUMN unique_item BOOLEAN NOT NULL DEFAULT FALSE",
+        )
+
+    if "unique_quantity" not in columns:
+        current_app.logger.info("Adding column stock_nodes.unique_quantity")
+        _execute_ignore_duplicate(
+            conn,
+            "ALTER TABLE stock_nodes ADD COLUMN unique_quantity INTEGER",
+        )
+
+
+def _ensure_event_stock_columns(conn: Connection, inspector) -> None:
+    columns = {col["name"] for col in inspector.get_columns("event_stock")}
+
+    if "selected_quantity" not in columns:
+        current_app.logger.info("Adding column event_stock.selected_quantity")
+        _execute_ignore_duplicate(
+            conn,
+            "ALTER TABLE event_stock ADD COLUMN selected_quantity INTEGER",
+        )
+
+
+def _execute_ignore_duplicate(conn: Connection, sql: str) -> None:
+    try:
+        conn.execute(text(sql))
+    except ProgrammingError as exc:  # pragma: no cover - defensive
+        if getattr(getattr(exc, "orig", None), "pgcode", None) != "42701":
+            raise
+    except OperationalError as exc:  # pragma: no cover - SQLite path
+        if "duplicate column" not in str(exc).lower():
+            raise

--- a/web/app/templates/event.html
+++ b/web/app/templates/event.html
@@ -126,8 +126,9 @@ function el(tag, attrs={}, ...children){
   for(const c of children){ if(c!=null) e.append(c.nodeType?c:document.createTextNode(c)); }
   return e;
 }
-const isItem = n => (n.type||"").toUpperCase()==="ITEM";
-const isGroup = n => (n.type||"").toUpperCase()==="GROUP";
+const isUnique = n => !!(n && n.unique_item);
+const isItem = n => (n && ((n.type||"").toUpperCase()==="ITEM" || isUnique(n)));
+const isGroup = n => !isItem(n);
 function normStatus(s){
   s = (s||"").toUpperCase();
   if(s==="OK") return "OK";

--- a/web/app/templates/home.html
+++ b/web/app/templates/home.html
@@ -17,7 +17,10 @@
         {% if roots and roots|length %}
           {% for r in roots %}
             <label class="btn ghost" style="cursor:pointer;">
-              <input type="checkbox" class="root-cb" value="{{ r.id }}" style="margin-right:6px">
+              <input type="checkbox" class="root-cb" value="{{ r.id }}" style="margin-right:6px"
+                     data-name="{{ r.name }}"
+                     data-unique="{{ 1 if r.unique_item else 0 }}"
+                     data-max="{{ r.unique_quantity if r.unique_quantity is not none else '' }}">
               {{ r.name }}
             </label>
           {% endfor %}
@@ -68,6 +71,67 @@
 <script>
 (function(){
   const byId = (id)=>document.getElementById(id);
+  const rootSelections = new Map();
+
+  function updateRootBadge(cb){
+    const wrap = cb.closest('label');
+    if(!wrap) return;
+    let badge = wrap.querySelector('.root-qty');
+    const id = parseInt(cb.value, 10);
+    const qty = rootSelections.get(id);
+    if(badge && (!cb.checked || qty==null)){
+      badge.remove();
+      badge = null;
+    }
+    if(cb.checked && qty != null){
+      if(!badge){
+        badge = document.createElement('span');
+        badge.className = 'badge root-qty';
+        badge.style.marginLeft = '6px';
+        wrap.appendChild(badge);
+      }
+      badge.textContent = `Qté: ${qty}`;
+    }
+  }
+
+  document.querySelectorAll('.root-cb').forEach(cb => {
+    cb.addEventListener('change', () => {
+      const id = parseInt(cb.value, 10);
+      const isUnique = (cb.dataset.unique === '1');
+      if(cb.checked){
+        if(isUnique){
+          const maxRaw = cb.dataset.max;
+          const max = maxRaw ? parseInt(maxRaw, 10) : null;
+          const current = rootSelections.get(id) ?? (max ?? 1);
+          const label = cb.dataset.name || 'parent';
+          let msg = `Quantité désirée pour ${label}`;
+          if(max != null){ msg += ` (max ${max})`; }
+          let input = prompt(msg, String(current));
+          if(input === null){
+            cb.checked = false;
+            return;
+          }
+          let qty = parseInt(input, 10);
+          if(isNaN(qty) || qty < 0){
+            alert('Quantité invalide');
+            cb.checked = false;
+            return;
+          }
+          if(max != null && qty > max){
+            alert(`Quantité supérieure au maximum (${max}).`);
+            cb.checked = false;
+            return;
+          }
+          rootSelections.set(id, qty);
+        }else{
+          rootSelections.delete(id);
+        }
+      }else{
+        rootSelections.delete(id);
+      }
+      updateRootBadge(cb);
+    });
+  });
 
   // -------- Création --------
   let creating = false;
@@ -75,17 +139,31 @@
     if (creating) return;
     const name = byId('ev-name').value.trim();
     const date = byId('ev-date').value || null;
-    const rootIds = Array.from(document.querySelectorAll('.root-cb:checked')).map(cb => parseInt(cb.value,10));
+    const selectedCbs = Array.from(document.querySelectorAll('.root-cb:checked'));
+    const rootsPayload = [];
+    for(const cb of selectedCbs){
+      const id = parseInt(cb.value, 10);
+      const isUnique = (cb.dataset.unique === '1');
+      if(isUnique){
+        if(!rootSelections.has(id)){
+          alert(`Sélectionne une quantité pour ${cb.dataset.name || 'ce parent'}.`);
+          return;
+        }
+        rootsPayload.push({id, quantity: rootSelections.get(id)});
+      }else{
+        rootsPayload.push({id});
+      }
+    }
 
     if(!name){ alert("Nom requis"); return; }
-    if(rootIds.length === 0){ alert("Sélectionne au moins un parent"); return; }
+    if(rootsPayload.length === 0){ alert("Sélectionne au moins un parent"); return; }
 
     creating = true;
     try {
       const res = await fetch('/events', {
         method: 'POST',
         headers: {'Content-Type':'application/json', 'Accept':'application/json'},
-        body: JSON.stringify({ name, date, root_ids: rootIds })
+        body: JSON.stringify({ name, date, roots: rootsPayload })
       });
 
       const text = await res.text();

--- a/web/app/templates/manage.html
+++ b/web/app/templates/manage.html
@@ -153,6 +153,18 @@
         </div>
       </div>
     </div>
+    <div id="add-group-fields" style="display:none;margin-top:8px">
+      <label style="display:flex;align-items:center;gap:8px">
+        <input id="add-unique" type="checkbox">
+        Objet unique (demande une quantité lors de l'ajout à un événement)
+      </label>
+      <div id="add-unique-qty-wrap" class="row" style="margin-top:8px;display:none">
+        <div style="flex:1;min-width:160px">
+          <label>Quantité maximale</label>
+          <input id="add-unique-qty" type="number" min="0" value="1">
+        </div>
+      </div>
+    </div>
     <div class="actions">
       <button class="btn" onclick="closeAddModal()">Annuler</button>
       <button class="btn primary" onclick="confirmAdd()">Ajouter</button>
@@ -177,6 +189,18 @@
       <div style="flex:1;min-width:180px" id="edit-expiry-wrap">
         <label>Péremption (résumé)</label>
         <input id="edit-expiry" type="date">
+      </div>
+    </div>
+    <div id="edit-group-fields" style="display:none;margin-top:8px">
+      <label style="display:flex;align-items:center;gap:8px">
+        <input id="edit-unique" type="checkbox">
+        Objet unique (demande une quantité lors de l'ajout à un événement)
+      </label>
+      <div id="edit-unique-qty-wrap" class="row" style="margin-top:8px;display:none">
+        <div style="flex:1;min-width:160px">
+          <label>Quantité maximale</label>
+          <input id="edit-unique-qty" type="number" min="0" value="1">
+        </div>
       </div>
     </div>
     <div id="edit-expiries-section" style="display:none;margin-top:12px">
@@ -377,6 +401,10 @@ function nodeEl(n){
 
   const name = h('div', {class:'name'}, `${n.name}  (lvl ${n.level}, ${n.type})`);
   name.style.cursor = 'pointer';
+  if(n.unique_item){
+    const maxTxt = (n.unique_quantity != null) ? `max ${n.unique_quantity}` : 'unique';
+    name.append(' ', h('span', {class:'badge', style:'margin-left:6px'}, `Objet unique (${maxTxt})`));
+  }
   if(n.type==='ITEM'){
     const b = h('span', {class:'badge '+perempClass(n.expiry_date), style:'margin-left:8px'}, perempLabel(n.expiry_date));
     name.append(' ', b);
@@ -698,9 +726,14 @@ function openEditModal(nodeId){
   const qtyWrap = document.getElementById('edit-qty-wrap');
   const expWrap = document.getElementById('edit-expiry-wrap');
   const expSection = document.getElementById('edit-expiries-section');
+  const groupFields = document.getElementById('edit-group-fields');
+  const uniqueCb = document.getElementById('edit-unique');
+  const uniqueQtyWrap = document.getElementById('edit-unique-qty-wrap');
+  const uniqueQtyInput = document.getElementById('edit-unique-qty');
   if(n.type === 'ITEM'){
     qtyWrap.style.display = '';
     expWrap.style.display = '';
+    if(groupFields) groupFields.style.display = 'none';
     document.getElementById('edit-qty').value = n.quantity ?? 0;
     document.getElementById('edit-expiry').value = n.expiry_date || '';
     if(expSection) expSection.style.display = '';
@@ -719,6 +752,18 @@ function openEditModal(nodeId){
     qtyWrap.style.display = 'none';
     expWrap.style.display = 'none';
     if(expSection) expSection.style.display = 'none';
+    if(groupFields){
+      groupFields.style.display = '';
+      if(uniqueCb){
+        uniqueCb.checked = !!n.unique_item;
+      }
+      if(uniqueQtyInput){
+        uniqueQtyInput.value = n.unique_quantity ?? 0;
+      }
+      if(uniqueQtyWrap){
+        uniqueQtyWrap.style.display = (uniqueCb && uniqueCb.checked) ? '' : 'none';
+      }
+    }
   }
   document.getElementById('editModal').classList.add('show');
 }
@@ -737,6 +782,12 @@ function closeEditModal(){
   if(info){ info.textContent = 'Ajoute une ligne par lot.'; }
   const openBtn = document.getElementById('edit-exp-open-page');
   if(openBtn){ openBtn.onclick = null; }
+  const groupFields = document.getElementById('edit-group-fields');
+  const uniqueQtyWrap = document.getElementById('edit-unique-qty-wrap');
+  const uniqueCb = document.getElementById('edit-unique');
+  if(groupFields) groupFields.style.display = 'none';
+  if(uniqueQtyWrap) uniqueQtyWrap.style.display = 'none';
+  if(uniqueCb) uniqueCb.checked = false;
   ['edit-exp-new-date','edit-exp-new-qty','edit-exp-new-lot','edit-exp-new-note'].forEach(id=>{
     const el = document.getElementById(id);
     if(el) el.value = '';
@@ -754,6 +805,17 @@ async function confirmEdit(){
     payload.quantity = q;
     const ex = document.getElementById('edit-expiry').value;
     payload.expiry_date = ex || null;
+  }else{
+    const uniqueCb = document.getElementById('edit-unique');
+    const uniqueQtyInput = document.getElementById('edit-unique-qty');
+    if(uniqueCb){
+      payload.unique_item = !!uniqueCb.checked;
+      if(uniqueCb.checked){
+        const uq = parseInt((uniqueQtyInput?.value || '0'), 10);
+        if(isNaN(uq) || uq < 0){ alert('Quantité maximale invalide'); return; }
+        payload.unique_quantity = uq;
+      }
+    }
   }
   try{
     await api('/stock/'+nodeId, {method:'PATCH', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)});
@@ -771,14 +833,35 @@ function openAddModal(parentId, defaultType){
   document.getElementById('add-name').value = '';
   document.getElementById('add-qty').value = 1;
   document.getElementById('add-expiry').value = '';
-  document.getElementById('add-item-fields').style.display = (typeSel.value === 'ITEM') ? '' : 'none';
+  const addItemFields = document.getElementById('add-item-fields');
+  const addGroupFields = document.getElementById('add-group-fields');
+  const uniqueCb = document.getElementById('add-unique');
+  const uniqueQtyWrap = document.getElementById('add-unique-qty-wrap');
+  const uniqueQtyInput = document.getElementById('add-unique-qty');
+  if(addItemFields) addItemFields.style.display = (typeSel.value === 'ITEM') ? '' : 'none';
+  if(addGroupFields) addGroupFields.style.display = (typeSel.value === 'GROUP') ? '' : 'none';
+  if(uniqueCb){ uniqueCb.checked = false; }
+  if(uniqueQtyInput){ uniqueQtyInput.value = 1; }
+  if(uniqueQtyWrap){ uniqueQtyWrap.style.display = 'none'; }
   document.getElementById('addModal').classList.add('show');
   document.getElementById('add-name').focus();
 }
 function closeAddModal(){ document.getElementById('addModal').classList.remove('show'); ADD_PARENT_ID = null; }
 document.addEventListener('change', (e)=>{
   if(e.target && e.target.id === 'add-type'){
-    document.getElementById('add-item-fields').style.display = (e.target.value === 'ITEM') ? '' : 'none';
+    const isItem = (e.target.value === 'ITEM');
+    const addItemFields = document.getElementById('add-item-fields');
+    const addGroupFields = document.getElementById('add-group-fields');
+    if(addItemFields) addItemFields.style.display = isItem ? '' : 'none';
+    if(addGroupFields) addGroupFields.style.display = isItem ? 'none' : '';
+  }
+  if(e.target && e.target.id === 'add-unique'){
+    const wrap = document.getElementById('add-unique-qty-wrap');
+    if(wrap) wrap.style.display = e.target.checked ? '' : 'none';
+  }
+  if(e.target && e.target.id === 'edit-unique'){
+    const wrap = document.getElementById('edit-unique-qty-wrap');
+    if(wrap) wrap.style.display = e.target.checked ? '' : 'none';
   }
 });
 async function confirmAdd(){
@@ -792,6 +875,14 @@ async function confirmAdd(){
     payload.quantity = q;
     const ex = document.getElementById('add-expiry').value;
     if(ex) payload.expiry_date = ex;
+  }else{
+    const uniqueCb = document.getElementById('add-unique');
+    if(uniqueCb && uniqueCb.checked){
+      const uq = parseInt((document.getElementById('add-unique-qty').value || '0'), 10);
+      if(isNaN(uq) || uq < 0){ alert('Quantité maximale invalide'); return; }
+      payload.unique_item = true;
+      payload.unique_quantity = uq;
+    }
   }
   try{
     const res = await api('/stock', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload) });

--- a/web/app/templates/public_event.html
+++ b/web/app/templates/public_event.html
@@ -205,8 +205,9 @@ function el(tag, attrs={}, ...children){
   for(const c of children){ if(c!=null) e.append(c.nodeType?c:document.createTextNode(c)); }
   return e;
 }
-const isItem  = n => (n.type||"").toUpperCase()==="ITEM";
-const isGroup = n => (n.type||"").toUpperCase()==="GROUP";
+const isUnique = n => !!(n && n.unique_item);
+const isItem  = n => (n && ((n.type||"").toUpperCase()==="ITEM" || isUnique(n)));
+const isGroup = n => !isItem(n);
 function normStatus(s){
   s = (s||"").toUpperCase();
   if(s==="OK") return "OK";


### PR DESCRIPTION
## Summary
- check for the new unique stock columns at startup and add them automatically when missing
- add a schema compatibility helper that safely alters `stock_nodes` and `event_stock`

## Testing
- python -m compileall web/app

------
https://chatgpt.com/codex/tasks/task_e_68ded217d7688331b692d870c686281b