### PR TITLE
Restore parent tree helpers on event pages

### DIFF
--- a/web/app/templates/event.html
+++ b/web/app/templates/event.html
@@ -127,7 +127,15 @@ function el(tag, attrs={}, ...children){
   return e;
 }
 const isUnique = n => !!(n && n.unique_item);
-const isItem = n => (n && ((n.type||"").toUpperCase()==="ITEM" || isUnique(n)));
+const isUniqueParent = n => !!(n && n.unique_parent);
+const targetNodeId = n => (n && (n.target_node_id || n.id));
+const domSafeId = id => String(id).replace(/[^a-zA-Z0-9_-]/g, "-");
+const isItem = n => {
+  if(!n) return false;
+  if(isUniqueParent(n)) return false;
+  const type = (n.type||"").toUpperCase();
+  return type === "ITEM" || (!!n.unique_item && !isUniqueParent(n));
+};
 const isGroup = n => !isItem(n);
 function normStatus(s){
   s = (s||"").toUpperCase();
@@ -234,6 +242,7 @@ function renderUniqueParentRow(n){
   const statusLbl = s==="OK" ? "✅ OK" : (s==="NOT_OK" ? "❌ Non conforme" : "⏳ En attente");
   const by = n.last_by ? ` (${n.last_by})` : "";
   const actionsEnabled = IS_OPEN;
+  const targetId = targetNodeId(n);
   const safeId = domSafeId(n.id);
   const qtyValue = (n.selected_quantity != null) ? n.selected_quantity : (n.quantity != null ? n.quantity : (n.unique_quantity != null ? n.unique_quantity : 1));
 
@@ -244,8 +253,8 @@ function renderUniqueParentRow(n){
   ITEM_STATUS_TXT.set(n.id, statusDiv);
 
   const right = el("div", {class:"row"},
-    el("button", {class:"btn success", disabled:!actionsEnabled, onclick:()=>verify(n.id,"OK")}, "OK"),
-    el("button", {class:"btn ghost", disabled:!actionsEnabled, onclick:()=>verify(n.id,"NOT_OK")}, "Non conforme"),
+    el("button", {class:"btn success", disabled:!actionsEnabled, onclick:()=>verify(targetId,"OK")}, "OK"),
+    el("button", {class:"btn ghost", disabled:!actionsEnabled, onclick:()=>verify(targetId,"NOT_OK")}, "Non conforme"),
   );
 
   const wrap = el("div", {class:`item unique-parent ${itemStateClass(n)}`, id:`item-${safeId}`},

--- a/web/app/templates/public_event.html
+++ b/web/app/templates/public_event.html
@@ -206,7 +206,15 @@ function el(tag, attrs={}, ...children){
   return e;
 }
 const isUnique = n => !!(n && n.unique_item);
-const isItem  = n => (n && ((n.type||"").toUpperCase()==="ITEM" || isUnique(n)));
+const isUniqueParent = n => !!(n && n.unique_parent);
+const targetNodeId = n => (n && (n.target_node_id || n.id));
+const domSafeId = id => String(id).replace(/[^a-zA-Z0-9_-]/g, "-");
+const isItem  = n => {
+  if(!n) return false;
+  if(isUniqueParent(n)) return false;
+  const type = (n.type||"").toUpperCase();
+  return type === "ITEM" || (!!n.unique_item && !isUniqueParent(n));
+};
 const isGroup = n => !isItem(n);
 function normStatus(s){
   s = (s||"").toUpperCase();
@@ -327,6 +335,32 @@ function renderItem(n){
   );
 
   const wrap = el("div",{class:"item "+(s==="OK"?"state-ok":(s==="NOT_OK"?"state-bad":"state-wait")), id:`item-${safeId}`}, left, right);
+  ITEM_EL.set(n.id, wrap);
+  return wrap;
+}
+
+function renderUniqueParentRow(n){
+  const s = normStatus(n.last_status);
+  const qtyValue = (n.selected_quantity != null)
+    ? n.selected_quantity
+    : (n.quantity != null ? n.quantity : (n.unique_quantity != null ? n.unique_quantity : 1));
+  const targetId = targetNodeId(n);
+  const safeId = domSafeId(n.id);
+
+  const left = el("div",{class:"left"},
+    el("span",{class:"status-dot "+(s==="OK"?"dot-ok":(s==="NOT_OK"?"dot-bad":"dot-wait"))}),
+    el("span",{class:"label"}, "Qté sélectionnée"),
+    el("span",{class:"qty"}, `Qté: ${qtyValue}`),
+    statusChip(s),
+    n.last_by ? el("span",{class:"meta"}, `• par ${n.last_by}`) : null
+  );
+
+  const right = el("div",{class:"right"},
+    el("button",{class:"btn xs success", onclick:()=>{ if(!ensureOperatorOrAsk()) return; verify(targetId,"OK"); }},"OK"),
+    el("button",{class:"btn xs ghost",   onclick:()=>{ if(!ensureOperatorOrAsk()) return; verify(targetId,"NOT_OK"); }},"Non conforme")
+  );
+
+  const wrap = el("div",{class:`item unique-parent ${s==="OK"?"state-ok":(s==="NOT_OK"?"state-bad":"state-wait")}`, id:`item-${safeId}`}, left, right);
   ITEM_EL.set(n.id, wrap);
   return wrap;
 }


### PR DESCRIPTION
## Summary
- restore the DOM/id helper utilities used by the event tree so parent and child nodes render again
- ensure unique parent rows exist on public and internal event views and their actions target the correct node id

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dee091a23c83318379ac8ec6c66899