### PR TITLE
Fix unique parent actions and status updates

### DIFF
--- a/web/app/templates/event.html
+++ b/web/app/templates/event.html
@@ -153,20 +153,11 @@ function normStatus(s){
 
 /* ---------- Statuts ---------- */
 function groupAllOk(n){
-  let ok = true, hasItem=false;
-  (function rec(x){
-    if(isItem(x)){ hasItem=true; ok = ok && (normStatus(x.last_status)==="OK"); }
-    (x.children||[]).forEach(rec);
-  })(n);
-  return hasItem && ok;
+  const items = flattenItems([n]);
+  return items.length > 0 && items.every(i => normStatus(i.last_status) === "OK");
 }
 function groupHasBad(n){
-  let bad = false;
-  (function rec(x){
-    if(isItem(x) && normStatus(x.last_status)==="NOT_OK") bad = true;
-    (x.children||[]).forEach(rec);
-  })(n);
-  return bad;
+  return flattenItems([n]).some(i => normStatus(i.last_status) === "NOT_OK");
 }
 function groupStatus(n){
   if(groupAllOk(n)) return "OK";
@@ -260,7 +251,7 @@ function renderUniqueParentRow(n){
   ITEM_STATUS_TXT.set(n.id, statusDiv);
 
   const right = el("div", {class:"row"},
-    el("button", {class:"btn success", disabled:!actionsEnabled, onclick:()=>verify(targetId,"OK")}, "Charger"),
+    el("button", {class:"btn success", disabled:!actionsEnabled, onclick:()=>verify(targetId,"OK")}, "OK"),
     el("button", {class:"btn ghost", disabled:!actionsEnabled, onclick:()=>verify(targetId,"NOT_OK")}, "Non conforme"),
   );
 
@@ -319,6 +310,8 @@ function applyItemDelta(local, incoming){
   local.last_status = normStatus(incoming.last_status || "PENDING");
   local.last_by = incoming.last_by || "";
   if(incoming.quantity != null) local.quantity = incoming.quantity;
+  if(typeof incoming.selected_quantity !== "undefined") local.selected_quantity = incoming.selected_quantity;
+  if(typeof incoming.unique_quantity !== "undefined") local.unique_quantity = incoming.unique_quantity;
   if(typeof incoming.target_node_id !== "undefined") local.target_node_id = incoming.target_node_id;
   if(typeof incoming.unique_from_parent !== "undefined") local.unique_from_parent = incoming.unique_from_parent;
 
@@ -342,7 +335,12 @@ function applyItemDelta(local, incoming){
   // 3) Texte d'état & quantité
   const label = s==="OK" ? "✅ OK" : (s==="NOT_OK" ? "❌ Non conforme" : "⏳ En attente");
   if(statusDiv) statusDiv.textContent = `Dernier statut: ${label}${local.last_by ? " ("+local.last_by+")" : ""}`;
-  if(qtySpan) qtySpan.textContent = `Qté: ${local.quantity ?? 1}`;
+  if(qtySpan){
+    const qtyVal = (local.selected_quantity != null)
+      ? local.selected_quantity
+      : (local.quantity != null ? local.quantity : (local.unique_quantity != null ? local.unique_quantity : 1));
+    qtySpan.textContent = `Qté: ${qtyVal}`;
+  }
 }
 
 function applyGroupDelta(local, incoming){

--- a/web/app/templates/public_event.html
+++ b/web/app/templates/public_event.html
@@ -363,7 +363,7 @@ function renderUniqueParentRow(n){
   );
 
   const right = el("div",{class:"right"},
-    el("button",{class:"btn xs success", onclick:()=>{ if(!ensureOperatorOrAsk()) return; verify(targetId,"OK"); }},"Charger"),
+    el("button",{class:"btn xs success", onclick:()=>{ if(!ensureOperatorOrAsk()) return; verify(targetId,"OK"); }},"OK"),
     el("button",{class:"btn xs ghost",   onclick:()=>{ if(!ensureOperatorOrAsk()) return; verify(targetId,"NOT_OK"); }},"Non conforme")
   );
 
@@ -467,7 +467,9 @@ function updateGroupStatsEl(n){
 
 function applyItemDelta(local, incoming){
   local.last_status = normStatus(incoming.last_status || "PENDING");
-  local.quantity    = (incoming.quantity!=null)?incoming.quantity:local.quantity;
+  if(incoming.quantity != null) local.quantity = incoming.quantity;
+  if(typeof incoming.selected_quantity !== "undefined") local.selected_quantity = incoming.selected_quantity;
+  if(typeof incoming.unique_quantity !== "undefined") local.unique_quantity = incoming.unique_quantity;
   local.last_by     = (incoming.last_by!=null)?incoming.last_by:local.last_by;
   if(typeof incoming.target_node_id !== "undefined") local.target_node_id = incoming.target_node_id;
   if(typeof incoming.unique_from_parent !== "undefined") local.unique_from_parent = incoming.unique_from_parent;
@@ -490,7 +492,12 @@ function applyItemDelta(local, incoming){
   }
 
   const q = box.querySelector(".qty");
-  if(q) q.textContent = `Qté: ${local.quantity != null ? local.quantity : 1}`;
+  if(q){
+    const qtyVal = (local.selected_quantity != null)
+      ? local.selected_quantity
+      : (local.quantity != null ? local.quantity : (local.unique_quantity != null ? local.unique_quantity : 1));
+    q.textContent = `Qté: ${qtyVal}`;
+  }
 
   const chip = box.querySelector(".chip.ok, .chip.bad, .chip.wait");
   if(chip){


### PR DESCRIPTION
## Summary
- rename the unique parent verification buttons to "OK" for consistency
- ensure quantity updates propagate for unique-parent rows
- update parent status aggregation to react to unique-parent validations on both dashboards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df8125b5d88331903d37b66ab228a2