### PR TITLE
Add scrollbars to modal popups

### DIFF
--- a/web/app/templates/manage.html
+++ b/web/app/templates/manage.html
@@ -60,7 +60,7 @@
   /* Modal */
   .modal{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.55);z-index:50}
   .modal.show{display:flex}
-  .modal .box{background:#0f1a2a;border:1px solid var(--border);border-radius:12px;padding:18px;max-width:600px;width:95%}
+  .modal .box{background:#0f1a2a;border:1px solid var(--border);border-radius:12px;padding:18px;max-width:600px;width:95%;max-height:calc(100vh - 40px);overflow-y:auto}
   .modal .row{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
   .modal label{display:block;margin-top:8px;font-size:14px;opacity:.85}
   .modal input, .modal select{width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:8px;background:#0f1e2f;color:var(--text)}

--- a/web/app/templates/public_event.html
+++ b/web/app/templates/public_event.html
@@ -104,8 +104,8 @@
   }
 
   .modal-back{position:fixed;inset:0;background:rgba(0,0,0,.55);display:flex;align-items:center;justify-content:center;z-index:60}
-  .modal-card{width:min(520px,92%);background:#0f1726;border:1px solid var(--border);border-radius:14px;padding:16px;box-shadow:var(--shadow)}
-  .modal{width:min(520px,92%);background:#0f1726;border:1px solid var(--border);border-radius:16px;padding:18px;box-shadow:var(--shadow)}
+  .modal-card{width:min(520px,92%);background:#0f1726;border:1px solid var(--border);border-radius:14px;padding:16px;box-shadow:var(--shadow);max-height:calc(100vh - 40px);overflow-y:auto}
+  .modal{width:min(520px,92%);background:#0f1726;border:1px solid var(--border);border-radius:16px;padding:18px;box-shadow:var(--shadow);max-height:calc(100vh - 40px);overflow-y:auto}
   .modal-card input{width:100%;margin:8px 0 12px 0;padding:10px;border-radius:10px;border:1px solid var(--border);background:#0b1120;color:#fff}
   .modal-actions{display:flex;gap:8px;justify-content:flex-end}
   .modal .field{display:flex;flex-direction:column;gap:6px}

--- a/web/app/templates/reassort.html
+++ b/web/app/templates/reassort.html
@@ -23,7 +23,7 @@
   .muted{color:var(--muted)}
   .note{background:#16253b;padding:6px 8px;border-radius:8px;font-size:12px;border:1px dashed var(--border);color:#cfe2ff}
   .modal-back{position:fixed;inset:0;background:rgba(0,0,0,.55);display:flex;align-items:center;justify-content:center;z-index:60}
-  .modal{background:#0f1726;border:1px solid var(--border);border-radius:16px;padding:18px;box-shadow:var(--shadow);width:min(480px,94%)}
+  .modal{background:#0f1726;border:1px solid var(--border);border-radius:16px;padding:18px;box-shadow:var(--shadow);width:min(480px,94%);max-height:calc(100vh - 40px);overflow-y:auto}
   .modal h3{margin:0 0 10px 0}
   .modal .field{display:flex;flex-direction:column;gap:6px;margin-top:10px}
   .modal input,.modal textarea{width:100%;padding:10px;border-radius:10px;border:1px solid var(--border);background:#0b1120;color:#fff}


### PR DESCRIPTION
## Summary
- allow stock management modals to scroll when content exceeds the viewport height
- enable scrolling inside reassort and public event modal dialogs to reach all actions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df8f5ea4b883319b18baaa5ae5706a