### PR TITLE
Fix CSP header formatting to avoid newline errors

### DIFF
--- a/web/app/config.py
+++ b/web/app/config.py
@@ -15,16 +15,19 @@ class BaseConfig:
     REMEMBER_COOKIE_HTTPONLY = True
     PREFERRED_URL_SCHEME = "https"
     REDIS_URL = os.environ.get("REDIS_URL", "redis://redis:6379/0")
+    _DEFAULT_CSP_DIRECTIVES = [
+        "default-src 'self'",
+        "img-src 'self' data:",
+        "style-src 'self' 'unsafe-inline'",
+        "script-src 'self' 'unsafe-inline' https://cdn.socket.io",
+        "connect-src 'self' ws: wss:",
+        "font-src 'self' data:",
+        "manifest-src 'self'",
+        "frame-ancestors 'none'",
+    ]
     CONTENT_SECURITY_POLICY = os.environ.get(
         "CONTENT_SECURITY_POLICY",
-        """default-src 'self'; "
-        "img-src 'self' data:; "
-        "style-src 'self' 'unsafe-inline'; "
-        "script-src 'self' 'unsafe-inline' https://cdn.socket.io; "
-        "connect-src 'self' ws: wss:; "
-        "font-src 'self' data:; "
-        "manifest-src 'self'; "
-        "frame-ancestors 'none'"""
+        "; ".join(_DEFAULT_CSP_DIRECTIVES),
     )
     STRICT_TRANSPORT_SECURITY = os.environ.get(
         "STRICT_TRANSPORT_SECURITY",

--- a/web/app/security.py
+++ b/web/app/security.py
@@ -130,6 +130,8 @@ def init_security(app) -> LoginRateLimiter:
     app.extensions["login_rate_limiter"] = limiter
 
     csp = app.config.get("CONTENT_SECURITY_POLICY")
+    if isinstance(csp, str):
+        csp = " ".join(segment for segment in csp.splitlines() if segment).strip() or None
     hsts = app.config.get("STRICT_TRANSPORT_SECURITY")
 
     @app.after_request


### PR DESCRIPTION
## Summary
- ensure the default Content-Security-Policy configuration is generated without embedded newline characters
- normalize configured CSP values before applying response headers to prevent header formatting errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df971355a08331a793ecbc71e243d9