### PR TITLE
Add periodic verification workflow

### DIFF
--- a/web/app/__init__.py
+++ b/web/app/__init__.py
@@ -85,6 +85,7 @@ def create_app() -> Flask:
 
     # Verify contient aussi les routes publiques /public/event/<token>/...
     _register_bp_if_any(app, "app.verify.views")
+    _register_bp_if_any(app, "app.verification_periodique.views")
 
     # Events API (POST /events, GET /events/<id>/tree, etc.)
     _register_bp_if_any(app, "app.events.views", candidates=("bp", "bp_events", "bp_public"))

--- a/web/app/events/views.py
+++ b/web/app/events/views.py
@@ -37,7 +37,12 @@ def _is_manager() -> bool:
     return current_user.is_authenticated and current_user.role in (Role.ADMIN, Role.CHEF)
 
 def _can_view() -> bool:
-    return current_user.is_authenticated and current_user.role in (Role.ADMIN, Role.CHEF, Role.VIEWER)
+    return current_user.is_authenticated and current_user.role in (
+        Role.ADMIN,
+        Role.CHEF,
+        Role.VIEWER,
+        getattr(Role, "VERIFICATIONPERIODIQUE", Role.VIEWER),
+    )
 
 def _event_or_404(event_id: int) -> Event:
     ev = db.session.get(Event, int(event_id))

--- a/web/app/peremption/views.py
+++ b/web/app/peremption/views.py
@@ -15,7 +15,12 @@ bp_peremption = Blueprint("peremption", __name__)
 
 # ---------------- Helpers accès ----------------
 def _can_view() -> bool:
-    return current_user.is_authenticated and current_user.role in (Role.ADMIN, Role.CHEF, Role.VIEWER)
+    return current_user.is_authenticated and current_user.role in (
+        Role.ADMIN,
+        Role.CHEF,
+        Role.VIEWER,
+        getattr(Role, "VERIFICATIONPERIODIQUE", Role.VIEWER),
+    )
 
 # ---------------- Helpers data ----------------
 def _build_path(n: StockNode) -> str:

--- a/web/app/reports/views.py
+++ b/web/app/reports/views.py
@@ -16,7 +16,12 @@ def _can_view_reports() -> bool:
         from ..models import Role  # import local pour éviter cycles
         return (
             current_user.is_authenticated
-            and getattr(current_user, "role", None) in (Role.ADMIN, Role.CHEF, Role.VIEWER)
+            and getattr(current_user, "role", None) in (
+                Role.ADMIN,
+                Role.CHEF,
+                Role.VIEWER,
+                getattr(Role, "VERIFICATIONPERIODIQUE", Role.VIEWER),
+            )
         )
     except Exception:
         # Si on ne peut pas importer, on restreint aux utilisateurs authentifiés

--- a/web/app/schema_compat.py
+++ b/web/app/schema_compat.py
@@ -42,6 +42,8 @@ def ensure_schema_compatibility() -> None:
 
         _ensure_event_template_tables(conn, tables)
         _ensure_reassort_tables(conn)
+        _ensure_periodic_verification_table(conn)
+        _ensure_role_enum_value(conn)
 
 
 def _ensure_stock_nodes_columns(conn: Connection, inspector) -> None:
@@ -96,6 +98,66 @@ def _ensure_reassort_tables(conn: Connection) -> None:
         ReassortBatch.__table__.create(bind=conn, checkfirst=True)
     except Exception as exc:  # pragma: no cover - garde-fou
         current_app.logger.warning("Unable to ensure reassort tables: %s", exc)
+
+
+def _ensure_periodic_verification_table(conn: Connection) -> None:
+    try:
+        from .models import PeriodicVerificationRecord  # import tardif
+    except Exception:
+        return
+
+    try:
+        PeriodicVerificationRecord.__table__.create(bind=conn, checkfirst=True)
+    except Exception as exc:  # pragma: no cover - garde-fou
+        current_app.logger.warning("Unable to ensure periodic verification table: %s", exc)
+
+
+def _ensure_role_enum_value(conn: Connection) -> None:
+    """Ensure the Role enum accepts the VERIFICATIONPERIODIQUE value (PostgreSQL)."""
+    try:
+        if conn.dialect.name != "postgresql":
+            return
+    except Exception:  # pragma: no cover - defensive
+        return
+
+    try:
+        row = conn.execute(
+            text(
+                "SELECT udt_name FROM information_schema.columns "
+                "WHERE table_name='users' AND column_name='role' LIMIT 1"
+            )
+        ).fetchone()
+    except Exception:  # pragma: no cover - defensive
+        return
+
+    if not row or not row[0]:
+        return
+
+    type_name = row[0]
+    try:
+        existing = conn.execute(
+            text(
+                "SELECT 1 FROM pg_type t "
+                "JOIN pg_enum e ON t.oid = e.enumtypid "
+                "WHERE t.typname = :type AND e.enumlabel = :label"
+            ),
+            {"type": type_name, "label": "verificationperiodique"},
+        ).fetchone()
+    except Exception:  # pragma: no cover - defensive
+        return
+
+    if existing:
+        return
+
+    quoted_type = f'"{type_name}"'
+    try:
+        conn.execute(
+            text(f"ALTER TYPE {quoted_type} ADD VALUE IF NOT EXISTS 'verificationperiodique'")
+        )
+    except ProgrammingError:
+        conn.execute(text(f"ALTER TYPE {quoted_type} ADD VALUE 'verificationperiodique'"))
+    except Exception as exc:  # pragma: no cover - garde-fou
+        current_app.logger.warning("Unable to extend role enum: %s", exc)
 
 def _execute_ignore_duplicate(conn: Connection, sql: str) -> None:
     try:

--- a/web/app/stats/views.py
+++ b/web/app/stats/views.py
@@ -18,7 +18,12 @@ bp = Blueprint("stats", __name__)
 # Droits
 # -------------------------------------------------
 def require_view() -> bool:
-    return current_user.is_authenticated and current_user.role in (Role.ADMIN, Role.CHEF, Role.VIEWER)
+    return current_user.is_authenticated and current_user.role in (
+        Role.ADMIN,
+        Role.CHEF,
+        Role.VIEWER,
+        getattr(Role, "VERIFICATIONPERIODIQUE", Role.VIEWER),
+    )
 
 # -------------------------------------------------
 # Statistiques d'un événement (existant)

--- a/web/app/templates/admin.html
+++ b/web/app/templates/admin.html
@@ -11,6 +11,7 @@
         <select name="role" required>
           <option value="CHEF">CHEF (chef de poste)</option>
           <option value="VIEWER">VIEWER (lecture seule)</option>
+          <option value="VERIFICATIONPERIODIQUE">VERIFICATIONPERIODIQUE (contrôles périodiques)</option>
           <option value="ADMIN">ADMIN (administrateur)</option>
         </select>
         <button class="btn primary" type="submit">Créer</button>
@@ -25,6 +26,7 @@
         <li>Ne te désactive pas toi-même 😉.</li>
         <li>Rôle <strong>CHEF</strong> : crée/modifie des événements, partage le lien.</li>
         <li>Rôle <strong>VIEWER</strong> : lecture seule des événements.</li>
+        <li>Rôle <strong>VERIFICATIONPERIODIQUE</strong> : accès dédié à la page de vérification périodique.</li>
       </ul>
     </div>
   </div>

--- a/web/app/templates/base.html
+++ b/web/app/templates/base.html
@@ -86,6 +86,10 @@
           <span id="peremp-badge" class="badge" style="display:none;margin-left:6px">0</span>
         </a>
 
+        {% if _cu.role and _cu.role.name in ['ADMIN', 'CHEF', 'VERIFICATIONPERIODIQUE'] %}
+          <a class="btn" href="/verification-periodique">✅ Vérification périodique</a>
+        {% endif %}
+
         {% if _cu.role and _cu.role.name in ['ADMIN', 'CHEF'] %}
           <a class="btn" href="/reassort">📦 Réassort</a>
         {% endif %}

--- a/web/app/templates/verification_periodique.html
+++ b/web/app/templates/verification_periodique.html
@@ -1,0 +1,261 @@
+{% extends "base.html" %}
+{% set title = "Vérification périodique" %}
+{% block content %}
+
+<div class="grid cols-2">
+  <div class="card">
+    <div class="title">Vérification périodique du matériel</div>
+    <div class="subtitle">Sélectionne un parent racine pour afficher son contenu et enregistre les contrôles sans créer d’événement.</div>
+    <div class="alert" style="margin-top:10px;">
+      <div class="muted">Rôles autorisés : ADMIN, CHEF et VERIFICATIONPERIODIQUE.</div>
+      <div class="muted" style="margin-top:6px;">Clique sur un parent dans la liste pour charger son arbre puis marque chaque item comme conforme ou non conforme.</div>
+    </div>
+  </div>
+  <div class="card">
+    <div class="title">Parents disponibles</div>
+    <div id="root-buttons" class="parents-bar" style="margin-top:8px;"></div>
+  </div>
+</div>
+
+<div class="card" style="margin-top:12px;">
+  <div class="row space-between">
+    <div>
+      <div class="title" id="current-root-name">Sélectionne un parent</div>
+      <div class="muted">Actualise automatiquement après chaque vérification.</div>
+    </div>
+    <div class="row wrap" style="gap:10px;">
+      <span class="chip ok" id="stat-ok">OK : 0</span>
+      <span class="chip bad" id="stat-bad">Non conformes : 0</span>
+      <span class="chip wait" id="stat-wait">En attente : 0</span>
+    </div>
+  </div>
+  <div class="progress" style="margin-top:10px;"><div id="progress-bar" style="width:0%"></div></div>
+  <div class="muted" id="progress-text" style="margin-top:6px;">0 / 0 vérifiés</div>
+</div>
+
+<div class="card" style="margin-top:12px;">
+  <div class="row space-between">
+    <div class="title">Matériel à contrôler</div>
+    <div class="muted">Vert = tout OK • Rouge = au moins un non conforme • Bleu = en attente</div>
+  </div>
+  <div id="tree" class="tree" style="margin-top:10px;"></div>
+</div>
+
+<script>
+const ROOTS = {{ (roots or [])|tojson }};
+let CURRENT_ROOT_ID = ROOTS.length ? ROOTS[0].id : null;
+let TREE = [];
+
+const NODE_MAP = new Map();
+const GROUP_EL = new Map();
+const ITEM_EL = new Map();
+const ITEM_STATUS_TXT = new Map();
+const ITEM_QTY_TXT = new Map();
+
+function el(tag, attrs={}, ...children){
+  const e = document.createElement(tag);
+  for(const [k,v] of Object.entries(attrs||{})){
+    if(k==="class") e.className = v;
+    else if(k==="html") e.innerHTML = v;
+    else if(k.startsWith("on") && typeof v === "function") e.addEventListener(k.slice(2), v);
+    else e.setAttribute(k, v);
+  }
+  for(const c of children){ if(c!=null) e.append(c.nodeType?c:document.createTextNode(c)); }
+  return e;
+}
+
+function indexTree(nodes){
+  NODE_MAP.clear();
+  (nodes||[]).forEach(function rec(n){
+    NODE_MAP.set(n.id, n);
+    (n.children||[]).forEach(rec);
+  });
+}
+
+const domSafeId = id => String(id).replace(/[^a-zA-Z0-9_-]/g, "-");
+const isItem = n => {
+  if(!n) return false;
+  if(n.unique_parent) return true;
+  const type = (n.type||"").toUpperCase();
+  return type === "ITEM" || (!!n.unique_item && !n.children?.length);
+};
+const isGroup = n => !isItem(n);
+const targetNodeId = n => (n && (n.target_node_id || n.id));
+function normStatus(s){
+  s = (s||"").toUpperCase();
+  if(s==="OK") return "OK";
+  if(s==="NOT_OK" || s==="NOT-OK" || s==="KO" || s==="NOK") return "NOT_OK";
+  return "PENDING";
+}
+
+function flattenItems(nodes){
+  const out=[];(nodes||[]).forEach(function rec(n){
+    if(isItem(n)) out.push(n);
+    (n.children||[]).forEach(rec);
+  });
+  return out;
+}
+function groupAllOk(n){
+  const items = flattenItems([n]);
+  return items.length>0 && items.every(i=>normStatus(i.last_status)==="OK");
+}
+function groupHasBad(n){
+  return flattenItems([n]).some(i=>normStatus(i.last_status)==="NOT_OK");
+}
+function groupStatus(n){
+  if(groupAllOk(n)) return "OK";
+  if(groupHasBad(n)) return "BAD";
+  return "WAIT";
+}
+
+function recomputeStats(stats){
+  if(!stats){
+    const items = flattenItems(TREE);
+    const total = items.length;
+    const ok = items.filter(i=>normStatus(i.last_status)==="OK").length;
+    const bad = items.filter(i=>normStatus(i.last_status)==="NOT_OK").length;
+    const wait = total - ok - bad;
+    updateStats(ok, bad, wait, total);
+  }else{
+    updateStats(stats.ok||0, stats.not_ok||0, stats.todo||0, stats.total||0);
+  }
+}
+
+function updateStats(ok, bad, wait, total){
+  document.getElementById("stat-ok").textContent = `OK : ${ok}`;
+  document.getElementById("stat-bad").textContent = `Non conformes : ${bad}`;
+  document.getElementById("stat-wait").textContent = `En attente : ${wait}`;
+  const pct = total ? Math.round(ok/total*100) : 0;
+  document.getElementById("progress-bar").style.width = pct+"%";
+  document.getElementById("progress-text").textContent = `${ok} / ${total} vérifiés`;
+}
+
+function itemStateClass(n){
+  const s = normStatus(n.last_status);
+  if(s==="OK") return "state-ok";
+  if(s==="NOT_OK") return "state-bad";
+  return "state-wait";
+}
+function groupStateClass(n){
+  const s = groupStatus(n);
+  if(s==="OK") return "state-ok";
+  if(s==="BAD") return "state-bad";
+  return "state-wait";
+}
+function statusDot(isOk,isBad){
+  return el("span", {class:"status-dot "+(isOk?"dot-ok":(isBad?"dot-bad":"dot-wait"))});
+}
+
+function renderItem(n){
+  const s = normStatus(n.last_status);
+  const statusLbl = s==="OK" ? "✅ OK" : (s==="NOT_OK" ? "❌ Non conforme" : "⏳ En attente");
+  const by = n.last_by ? ` (${n.last_by})` : "";
+  const targetId = targetNodeId(n);
+  const safeId = domSafeId(n.id);
+  const qtyValue = n.selected_quantity ?? n.quantity ?? n.unique_quantity ?? 1;
+  const qtySpan = el("span", {class:"qty", id:`qty-${safeId}`}, `Qté: ${qtyValue}`);
+  ITEM_QTY_TXT.set(n.id, qtySpan);
+  const statusDiv = el("div", {class:"muted", id:`status-${safeId}`}, `Dernier statut: ${statusLbl}${by}`);
+  ITEM_STATUS_TXT.set(n.id, statusDiv);
+  const wrap = el("div", {class:"item "+itemStateClass(n), id:`item-${safeId}`},
+    el("div", null,
+      el("div", {class:"name"}, statusDot(s==="OK", s==="NOT_OK"), " ", n.name, " ", qtySpan),
+      statusDiv
+    ),
+    el("div", {class:"row"},
+      el("button", {class:"btn success", onclick:()=>verify(targetId,"OK")}, "OK"),
+      el("button", {class:"btn ghost", onclick:()=>verify(targetId,"NOT_OK")}, "Non conforme"),
+      el("button", {class:"btn", onclick:()=>verify(targetId,"TODO")}, "Remettre en attente")
+    )
+  );
+  ITEM_EL.set(n.id, wrap);
+  return wrap;
+}
+
+function renderGroup(n){
+  const header = el("div", {class:"header"},
+    el("div", {class:"name"}, statusDot(groupStatus(n)==="OK", groupStatus(n)==="BAD"), " ", n.name)
+  );
+  const bodyChildren = [];
+  if(n.unique_item || n.unique_parent){
+    bodyChildren.push(renderItem(n));
+  }
+  (n.children||[]).forEach(child => bodyChildren.push(renderNode(child)));
+  const children = el("div", {class:"childs"}, ...bodyChildren);
+  const box = el("div", {class:`node ${groupStateClass(n)}`, id:`node-${n.id}`}, header, children);
+  GROUP_EL.set(n.id, box);
+  return box;
+}
+function renderNode(n){ return isGroup(n) ? renderGroup(n) : renderItem(n); }
+
+function buildTree(){
+  const container = document.getElementById("tree");
+  container.innerHTML = "";
+  GROUP_EL.clear();
+  ITEM_EL.clear();
+  ITEM_STATUS_TXT.clear();
+  ITEM_QTY_TXT.clear();
+  (TREE||[]).forEach(n => container.appendChild(renderNode(n)));
+  buildParentsBar();
+}
+
+function buildParentsBar(){
+  const bar = document.getElementById("root-buttons");
+  bar.innerHTML = "";
+  ROOTS.forEach(root => {
+    const pill = el("div", {
+      class:"parent-pill "+(root.id===CURRENT_ROOT_ID?"pill-ok":"pill-wait"),
+      onclick:()=>loadRoot(root.id)
+    }, root.name);
+    if(root.id===CURRENT_ROOT_ID){
+      pill.classList.add("focus-ring");
+    }
+    bar.appendChild(pill);
+  });
+}
+
+function updateCurrentRootName(name){
+  const elmt = document.getElementById("current-root-name");
+  if(elmt) elmt.textContent = name || "Sélectionne un parent";
+}
+
+function loadRoot(rootId){
+  if(!rootId) return;
+  CURRENT_ROOT_ID = rootId;
+  document.getElementById("tree").innerHTML = "<div class='muted'>Chargement…</div>";
+  fetch(`/verification-periodique/tree/${rootId}`, {credentials:"include"})
+    .then(r => r.ok ? r.json() : r.text().then(txt=>Promise.reject(txt)))
+    .then(data => {
+      TREE = data.tree || [];
+      indexTree(TREE);
+      updateCurrentRootName(data.root?.name || "");
+      buildTree();
+      recomputeStats(data.stats);
+    })
+    .catch(err => {
+      document.getElementById("tree").innerHTML = `<div class='muted'>Erreur de chargement : ${err}</div>`;
+    });
+}
+
+function verify(nodeId, status){
+  fetch(`/verification-periodique/verify`, {
+    method:"POST",
+    credentials:"include",
+    headers:{"Content-Type":"application/json"},
+    body: JSON.stringify({node_id: nodeId, status})
+  })
+  .then(r => r.ok ? r.json() : r.text().then(txt=>Promise.reject(txt)))
+  .then(()=> loadRoot(CURRENT_ROOT_ID))
+  .catch(err => alert(typeof err === "string" ? err : "Erreur réseau"));
+}
+
+(function init(){
+  if(!ROOTS.length){
+    document.getElementById("tree").innerHTML = "<div class='muted'>Aucun parent racine défini.</div>";
+    return;
+  }
+  buildParentsBar();
+  loadRoot(CURRENT_ROOT_ID);
+})();
+</script>
+{% endblock %}

--- a/web/app/verification_periodique/__init__.py
+++ b/web/app/verification_periodique/__init__.py
@@ -1,0 +1,2 @@
+# app/verification_periodique/__init__.py
+

--- a/web/app/verification_periodique/views.py
+++ b/web/app/verification_periodique/views.py
@@ -1,0 +1,314 @@
+"""Periodic verification endpoints."""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from flask import Blueprint, jsonify, request, abort
+from flask_login import current_user, login_required
+
+from .. import db
+from ..models import (
+    Role,
+    StockNode,
+    NodeType,
+    PeriodicVerificationRecord,
+    ItemStatus,
+    IssueCode,
+)
+from ..tree_query import tree_stats
+
+try:  # Optional table depending on migrations
+    from ..models import StockItemExpiry
+    HAS_EXP_MODEL = True
+except Exception:  # pragma: no cover - fallback when table missing
+    StockItemExpiry = None  # type: ignore
+    HAS_EXP_MODEL = False
+
+bp = Blueprint("verification_periodique", __name__, url_prefix="/verification-periodique")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _can_access() -> bool:
+    return current_user.is_authenticated and current_user.role in (
+        Role.ADMIN,
+        Role.CHEF,
+        Role.VERIFICATIONPERIODIQUE,
+    )
+
+
+def _ensure_table() -> None:
+    try:
+        PeriodicVerificationRecord.__table__.create(bind=db.engine, checkfirst=True)
+    except Exception:
+        db.session.rollback()
+
+
+def _norm_status(value: Any) -> str:
+    if value is None:
+        return "TODO"
+    if hasattr(value, "name"):
+        try:
+            return str(value.name).upper()
+        except Exception:  # pragma: no cover - defensive
+            pass
+    return str(value).upper()
+
+
+def _latest_map(node_ids: List[int]) -> Dict[int, Dict[str, Any]]:
+    if not node_ids:
+        return {}
+
+    rows = (
+        PeriodicVerificationRecord.query
+        .filter(PeriodicVerificationRecord.node_id.in_(node_ids))
+        .order_by(
+            PeriodicVerificationRecord.node_id.asc(),
+            PeriodicVerificationRecord.created_at.desc(),
+            PeriodicVerificationRecord.id.desc(),
+        )
+        .all()
+    )
+
+    latest: Dict[int, Dict[str, Any]] = {}
+    for row in rows:
+        nid = int(row.node_id)
+        if nid in latest:
+            continue
+        latest[nid] = {
+            "status": _norm_status(getattr(row, "status", None)),
+            "by": row.verifier_name or getattr(getattr(row, "verifier", None), "username", None),
+            "at": (getattr(row, "updated_at", None) or getattr(row, "created_at", None)),
+            "comment": getattr(row, "comment", None),
+            "issue_code": _norm_status(getattr(row, "issue_code", None)) if getattr(row, "issue_code", None) else None,
+            "observed_qty": getattr(row, "observed_qty", None),
+            "missing_qty": getattr(row, "missing_qty", None),
+        }
+        if latest[nid]["at"]:
+            latest[nid]["at"] = latest[nid]["at"].isoformat()
+    return latest
+
+
+def _expiries_for_items(item_ids: List[int]) -> Dict[int, List[StockItemExpiry]]:  # type: ignore[name-defined]
+    if not HAS_EXP_MODEL or not item_ids:
+        return {}
+    try:
+        rows = (
+            StockItemExpiry.query  # type: ignore[union-attr]
+            .filter(StockItemExpiry.node_id.in_(item_ids))  # type: ignore[union-attr]
+            .order_by(
+                StockItemExpiry.node_id.asc(),  # type: ignore[union-attr]
+                StockItemExpiry.expiry_date.asc(),  # type: ignore[union-attr]
+                StockItemExpiry.id.asc(),  # type: ignore[union-attr]
+            )
+            .all()
+        )
+    except Exception:
+        db.session.rollback()
+        return {}
+
+    out: Dict[int, List[StockItemExpiry]] = {}
+    for row in rows:
+        out.setdefault(int(row.node_id), []).append(row)
+    return out
+
+
+def _serialize(node: StockNode, latest: Dict[int, Dict[str, Any]], exp_map: Dict[int, List[StockItemExpiry]]) -> Dict[str, Any]:  # type: ignore[name-defined]
+    base: Dict[str, Any] = {
+        "id": node.id,
+        "name": node.name,
+        "type": node.type.name if hasattr(node.type, "name") else str(node.type),
+    }
+
+    if node.type == NodeType.ITEM:
+        info = latest.get(int(node.id), {})
+        expiries_payload: List[Dict[str, Any]] = []
+        if HAS_EXP_MODEL:
+            for e in exp_map.get(int(node.id), []):
+                expiries_payload.append(
+                    {
+                        "date": e.expiry_date.isoformat(),
+                        "quantity": e.quantity,
+                        "lot": e.lot,
+                        "note": e.note,
+                        "id": e.id,
+                    }
+                )
+        legacy_expiry = None
+        if expiries_payload:
+            legacy_expiry = expiries_payload[0]["date"]
+        elif getattr(node, "expiry_date", None):
+            legacy_expiry = node.expiry_date.isoformat()
+
+        base.update(
+            {
+                "last_status": info.get("status", "TODO"),
+                "last_by": info.get("by"),
+                "last_at": info.get("at"),
+                "comment": info.get("comment"),
+                "issue_code": info.get("issue_code"),
+                "observed_qty": info.get("observed_qty"),
+                "missing_qty": info.get("missing_qty"),
+                "quantity": node.quantity,
+                "expiry_date": legacy_expiry,
+                "expiries": expiries_payload,
+                "children": [],
+            }
+        )
+        return base
+
+    is_unique = bool(getattr(node, "unique_item", False))
+    children: List[Dict[str, Any]] = []
+    if is_unique:
+        info = latest.get(int(node.id), {})
+        qty = getattr(node, "unique_quantity", None)
+        base.update(
+            {
+                "unique_item": True,
+                "unique_parent": True,
+                "unique_quantity": qty,
+                "quantity": qty,
+                "selected_quantity": qty,
+                "last_status": info.get("status", "TODO"),
+                "last_by": info.get("by"),
+                "last_at": info.get("at"),
+                "comment": info.get("comment"),
+                "issue_code": info.get("issue_code"),
+                "observed_qty": info.get("observed_qty"),
+                "missing_qty": info.get("missing_qty"),
+                "children": [],
+            }
+        )
+    else:
+        ordered_children = sorted(node.children, key=lambda c: (c.level, c.id)) if hasattr(node, "children") else []
+        for child in ordered_children:
+            children.append(_serialize(child, latest, exp_map))
+        base["children"] = children
+
+    base["unique_item"] = is_unique
+    if is_unique:
+        base.setdefault("unique_quantity", getattr(node, "unique_quantity", None))
+    return base
+
+
+def _collect_item_ids(node: StockNode, collector: List[int]) -> None:
+    if node.type == NodeType.ITEM or getattr(node, "unique_item", False):
+        collector.append(int(node.id))
+        return
+    for child in getattr(node, "children", []) or []:
+        _collect_item_ids(child, collector)
+
+
+def _build_tree(root: StockNode) -> List[Dict[str, Any]]:
+    items: List[int] = []
+    _collect_item_ids(root, items)
+    latest = _latest_map(items)
+    exp_map = _expiries_for_items(items)
+    return [_serialize(root, latest, exp_map)]
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+@bp.get("/roots")
+@login_required
+def list_roots():
+    if not _can_access():
+        return jsonify(error="Forbidden"), 403
+
+    roots = (
+        StockNode.query
+        .filter(StockNode.parent_id.is_(None))
+        .order_by(StockNode.name.asc())
+        .all()
+    )
+    return jsonify([{"id": r.id, "name": r.name} for r in roots])
+
+
+@bp.get("/tree/<int:root_id>")
+@login_required
+def tree(root_id: int):
+    if not _can_access():
+        return jsonify(error="Forbidden"), 403
+
+    _ensure_table()
+
+    node = db.session.get(StockNode, root_id)
+    if not node:
+        return jsonify(error="Parent introuvable"), 404
+
+    while node.parent_id is not None:
+        node = node.parent
+
+    tree_payload = _build_tree(node)
+    stats = tree_stats(tree_payload)
+
+    return jsonify({
+        "root": {"id": node.id, "name": node.name},
+        "tree": tree_payload,
+        "stats": stats,
+    })
+
+
+@bp.post("/verify")
+@login_required
+def verify_item():
+    if not _can_access():
+        return jsonify(error="Forbidden"), 403
+
+    _ensure_table()
+
+    payload = request.get_json(silent=True) or {}
+    try:
+        node_id = int(payload.get("node_id") or 0)
+    except Exception:
+        return jsonify(error="node_id invalide"), 400
+
+    status_raw = (payload.get("status") or "").strip().upper()
+    status_map = {"OK": ItemStatus.OK, "NOT_OK": ItemStatus.NOT_OK, "TODO": ItemStatus.TODO}
+    status = status_map.get(status_raw)
+    if not node_id or status is None:
+        return jsonify(error="Paramètres invalides"), 400
+
+    node = db.session.get(StockNode, node_id)
+    if not node:
+        return jsonify(error="Item introuvable"), 404
+    if node.type != NodeType.ITEM and not getattr(node, "unique_item", False):
+        return jsonify(error="Seuls les items sont vérifiables"), 400
+
+    comment = (payload.get("comment") or "").strip() or None
+
+    issue_code = None
+    raw_issue = (payload.get("issue_code") or "").strip().upper()
+    if raw_issue:
+        issue_code = getattr(IssueCode, raw_issue, None)
+
+    def _safe_int(value: Any) -> int | None:
+        if value is None or value == "":
+            return None
+        try:
+            ivalue = int(value)
+        except Exception:
+            return None
+        if ivalue < 0:
+            return 0
+        return ivalue
+
+    observed_qty = _safe_int(payload.get("observed_qty"))
+    missing_qty = _safe_int(payload.get("missing_qty"))
+
+    rec = PeriodicVerificationRecord(
+        node_id=node.id,
+        status=status,
+        verifier_id=current_user.id,
+        verifier_name=getattr(current_user, "username", None),
+        comment=comment,
+        issue_code=issue_code,
+        observed_qty=observed_qty,
+        missing_qty=missing_qty,
+    )
+    db.session.add(rec)
+    db.session.commit()
+
+    return jsonify({"ok": True, "record_id": rec.id})


### PR DESCRIPTION
## Summary
- add a VERIFICATIONPERIODIQUE role and persistent periodic verification records for stock items
- expose REST endpoints and a new HTML page to review roots and record periodic checks without creating events
- extend permissions, navigation, and schema compatibility logic so the new role can access dashboards and existing exports

## Testing
- python -m compileall web/app

------
https://chatgpt.com/codex/tasks/task_e_68df987ea33c8331b01b95c0bf98fa4d