### PR TITLE
Fix periodic verification roots serialization

### DIFF
--- a/web/app/views_html.py
+++ b/web/app/views_html.py
@@ -333,4 +333,11 @@ def verification_periodique_page():
         .order_by(StockNode.name.asc())
         .all()
     )
-    return render_template("verification_periodique.html", roots=roots)
+    root_payload = [
+        {
+            "id": root.id,
+            "name": root.name,
+        }
+        for root in roots
+    ]
+    return render_template("verification_periodique.html", roots=root_payload)


### PR DESCRIPTION
## Summary
- convert periodic verification roots to plain dictionaries before rendering the template so the initial payload can be serialized to JSON

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df9c732558833193333a27cd8b27b3