### PR TITLE
Update event page collapsible layout and status toggle

### DIFF
--- a/web/app/templates/event.html
+++ b/web/app/templates/event.html
@@ -48,6 +48,13 @@
   .vehicle{font-size:12px; opacity:.9; padding:2px 6px; border-radius:6px; border:1px dashed var(--border); margin-left:8px}
   .vehicle.on{background:#0e2a24; color:#bff3e7; border-color:#1d6e5d}
   .vehicle.off{background:#101c2e; color:#b7c7dc; border-color:#24344f}
+  .header.toggle{display:flex;align-items:center;justify-content:space-between;padding:10px 12px;border-radius:10px;cursor:pointer}
+  .header.toggle:hover{background:rgba(255,255,255,.04)}
+  .header .left{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+  .header .group-name{font-weight:800}
+  .chev{width:18px;display:inline-flex;align-items:center;justify-content:center;opacity:.85}
+  .childs{padding:10px 12px 6px 28px}
+  .childs.collapsed{display:none}
 </style>
 
 <div class="grid cols-2">
@@ -57,12 +64,12 @@
         <div class="title">{{ event.name }}</div>
         <div class="muted">Date : {{ event.date or "—" }}</div>
       </div>
-      <span class="badge" id="status-badge">Statut : {{ event.status }}</span>
+      <span class="badge" id="status-badge">Statut : {{ event_status }}</span>
     </div>
     <div class="row wrap" style="margin-top:10px;">
       <a class="btn" target="_blank" href="/reports/event/{{ event.id }}/pdf">Exporter PDF</a>
       <button class="btn primary" id="btn-share">Lien secouristes</button>
-      <button class="btn" id="btn-close">Clôturer l'événement</button>
+      <button class="btn" id="btn-close">{{ "Clôturer l'événement" if event_status == "OPEN" else "Réouvrir l'événement" }}</button>
     </div>
   </div>
 
@@ -95,7 +102,8 @@
 const EVENT_ID = {{ event.id }};
 let TREE = {{ (tree or [])|tojson }};
 const CURRENT_USER = "{{ (current_user.username if current_user is defined and current_user.is_authenticated else '')|e }}";
-let IS_OPEN = ("{{ event.status }}".toUpperCase() === "OPEN");
+const SHOW_VERIFY = {{ 'true' if allow_verify else 'false' }};
+let IS_OPEN = ("{{ event_status }}".toUpperCase() === "OPEN");
 
 // ❌ Pas de “Charger” ici (réservé à la page publique)
 const ALLOW_CHARGE = false;
@@ -107,6 +115,7 @@ const ITEM_EL  = new Map();
 const ITEM_STATUS_TXT = new Map();
 const ITEM_QTY_TXT = new Map();
 const VEH_LABEL = new Map();
+const COLLAPSED = new Map();
 
 /* ---------- Utils ---------- */
 function indexTree(nodes){
@@ -209,20 +218,23 @@ function renderItem(n){
   const s = normStatus(n.last_status);
   const statusLbl = s==="OK" ? "✅ OK" : (s==="NOT_OK" ? "❌ Non conforme" : "⏳ En attente");
   const by = n.last_by ? ` (${n.last_by})` : "";
-  const actionsEnabled = IS_OPEN;
+  const actionsEnabled = IS_OPEN && SHOW_VERIFY;
   const targetId = targetNodeId(n);
   const safeId = domSafeId(n.id);
+  const qtyValue = (n.selected_quantity != null)
+    ? n.selected_quantity
+    : (n.quantity != null ? n.quantity : (n.unique_quantity != null ? n.unique_quantity : 1));
 
-  const qtySpan = el("span", {class:"qty", id:`qty-${safeId}`}, `Qté: ${n.quantity ?? 1}`);
+  const qtySpan = el("span", {class:"qty", id:`qty-${safeId}`}, `Qté: ${qtyValue}`);
   ITEM_QTY_TXT.set(n.id, qtySpan);
 
   const statusDiv = el("div", {class:"muted", id:`status-${safeId}`}, `Dernier statut: ${statusLbl}${by}`);
   ITEM_STATUS_TXT.set(n.id, statusDiv);
 
-  const right = el("div", {class:"row"},
+  const right = SHOW_VERIFY ? el("div", {class:"row"},
     el("button", {class:"btn success", disabled:!actionsEnabled, onclick:()=>verify(targetId,"OK")}, "OK"),
     el("button", {class:"btn ghost", disabled:!actionsEnabled, onclick:()=>verify(targetId,"NOT_OK")}, "Non conforme"),
-  );
+  ) : null;
 
   const wrap = el("div", {class:"item "+itemStateClass(n), id:`item-${safeId}`},
     el("div", null,
@@ -239,7 +251,7 @@ function renderUniqueParentRow(n){
   const s = normStatus(n.last_status);
   const statusLbl = s==="OK" ? "✅ OK" : (s==="NOT_OK" ? "❌ Non conforme" : "⏳ En attente");
   const by = n.last_by ? ` (${n.last_by})` : "";
-  const actionsEnabled = IS_OPEN;
+  const actionsEnabled = IS_OPEN && SHOW_VERIFY;
   const targetId = targetNodeId(n);
   const safeId = domSafeId(n.id);
   const qtyValue = (n.selected_quantity != null) ? n.selected_quantity : (n.quantity != null ? n.quantity : (n.unique_quantity != null ? n.unique_quantity : 1));
@@ -250,10 +262,10 @@ function renderUniqueParentRow(n){
   const statusDiv = el("div", {class:"muted", id:`status-${safeId}`}, `Dernier statut: ${statusLbl}${by}`);
   ITEM_STATUS_TXT.set(n.id, statusDiv);
 
-  const right = el("div", {class:"row"},
+  const right = SHOW_VERIFY ? el("div", {class:"row"},
     el("button", {class:"btn success", disabled:!actionsEnabled, onclick:()=>verify(targetId,"OK")}, "OK"),
     el("button", {class:"btn ghost", disabled:!actionsEnabled, onclick:()=>verify(targetId,"NOT_OK")}, "Non conforme"),
-  );
+  ) : null;
 
   const wrap = el("div", {class:`item unique-parent ${itemStateClass(n)}`, id:`item-${safeId}`},
     el("div", {class:"unique-info"},
@@ -273,12 +285,19 @@ function renderGroup(n){
   );
   VEH_LABEL.set(n.id, veh);
 
-  const headerLeft = el("div", {class:"name"},
-    statusDot(groupStatus(n)==="OK", groupStatus(n)==="BAD"), " ", n.name,
+  if(!COLLAPSED.has(n.id)) COLLAPSED.set(n.id, true);
+  const collapsed = !!COLLAPSED.get(n.id);
+  const gStatus = groupStatus(n);
+  const chev = el("span", {class:"chev", id:`chev-${n.id}`}, collapsed ? "▸" : "▾");
+  const headerLeft = el("div", {class:"left"},
+    chev,
+    statusDot(gStatus==="OK", gStatus==="BAD"),
+    el("span", {class:"group-name"}, n.name),
     n.is_event_root ? veh : null
   );
 
-  const header = el("div", {class:"header"}, headerLeft);
+  const header = el("div", {class:"header toggle"}, headerLeft);
+  header.addEventListener("click", ()=>toggleCollapse(n.id));
 
   // ❌ Aucun bouton “Charger” ici (réservé à la page publique)
   const bodyChildren = [];
@@ -288,12 +307,25 @@ function renderGroup(n){
   (n.children||[]).forEach(child => {
     bodyChildren.push(renderNode(child));
   });
-  const children = el("div", {class:"childs"}, ...bodyChildren);
+  const children = el("div", {class:`childs ${collapsed?"collapsed":""}`, id:`childs-${n.id}`}, ...bodyChildren);
   const box = el("div", {class:`node ${groupStateClass(n)}`, id:`node-${n.id}`}, header, children);
   GROUP_EL.set(n.id, box);
   return box;
 }
 function renderNode(n){ return isGroup(n) ? renderGroup(n) : renderItem(n); }
+
+function updateActionButtons(){
+  const enable = IS_OPEN && SHOW_VERIFY;
+  ITEM_EL.forEach(box => {
+    box.querySelectorAll("button").forEach(btn => { btn.disabled = !enable; });
+  });
+}
+function updateStatusUI(){
+  const badge = document.getElementById("status-badge");
+  if(badge) badge.textContent = `Statut : ${IS_OPEN ? "OPEN" : "CLOSED"}`;
+  const btn = document.getElementById("btn-close");
+  if(btn) btn.textContent = IS_OPEN ? "Clôturer l'événement" : "Réouvrir l'événement";
+}
 
 function buildUIOnce(){
   const root = document.getElementById("tree");
@@ -302,6 +334,8 @@ function buildUIOnce(){
   (TREE||[]).forEach(n => root.appendChild(renderNode(n)));
   buildParentsBar();
   recomputeStats();
+  updateActionButtons();
+  updateStatusUI();
 }
 
 /* ---------- MAJ incrémentales ---------- */
@@ -418,6 +452,7 @@ function syncTreeIncoming(incomingRoots){
   });
   updateParentsBarOnly();
   recomputeStats();
+  updateActionButtons();
 }
 
 /* ---------- Barre Parents ---------- */
@@ -440,7 +475,20 @@ function buildParentsBar(){
 function updateParentsBarOnly(){
   buildParentsBar();
 }
+function setCollapseState(id, collapsed){
+  const value = !!collapsed;
+  COLLAPSED.set(id, value);
+  const cont = document.getElementById("childs-"+id);
+  if(cont) cont.classList.toggle("collapsed", value);
+  const chev = document.getElementById("chev-"+id);
+  if(chev) chev.textContent = value ? "▸" : "▾";
+}
+function toggleCollapse(id){
+  const current = COLLAPSED.has(id) ? !!COLLAPSED.get(id) : false;
+  setCollapseState(id, !current);
+}
 function scrollToParent(id){
+  setCollapseState(id, false);
   const target = document.getElementById("node-"+id);
   if(!target) return;
   target.scrollIntoView({behavior:"smooth", block:"start"});
@@ -484,16 +532,26 @@ document.getElementById("btn-share").addEventListener("click", ()=>{
 });
 
 document.getElementById("btn-close").addEventListener("click", ()=>{
+  const nextStatus = IS_OPEN ? "CLOSED" : "OPEN";
   fetch(`/events/${EVENT_ID}/status`, {
     method:"PATCH", credentials:"include",
     headers:{"Content-Type":"application/json"},
-    body: JSON.stringify({status:"CLOSED"})
-  }).then(()=>{
-    IS_OPEN = false;
-    document.getElementById("status-badge").textContent = "Statut : CLOSED";
-    ITEM_EL.forEach(box=>{
-      box.querySelectorAll("button").forEach(b=> b.disabled = true);
-    });
+    body: JSON.stringify({status: nextStatus})
+  })
+  .then(res => {
+    if(!res.ok){
+      return res.text().then(txt => { throw new Error(txt || "Impossible de mettre à jour le statut."); });
+    }
+    return res.json().catch(()=>null);
+  })
+  .then(()=>{
+    IS_OPEN = (nextStatus === "OPEN");
+    updateActionButtons();
+    updateStatusUI();
+    refreshTree();
+  })
+  .catch(err => {
+    alert(err.message || "Erreur réseau");
   });
 });
 

--- a/web/app/views_html.py
+++ b/web/app/views_html.py
@@ -230,7 +230,16 @@ def event_page(event_id: int):
         abort(404)
     tree = build_event_tree(event_id)
     current_app.logger.info("[EVENT PAGE] ev_id=%s tree_roots=%s", ev.id, len(tree))
-    return render_template("event.html", event=ev, tree=tree)
+    status_raw = getattr(ev.status, "name", ev.status)
+    status_txt = str(status_raw).upper()
+    allow_verify = current_user.is_authenticated and current_user.role == Role.ADMIN
+    return render_template(
+        "event.html",
+        event=ev,
+        tree=tree,
+        event_status=status_txt,
+        allow_verify=allow_verify,
+    )
 
 # -------------------------
 # Page publique (secouristes via lien partagé)


### PR DESCRIPTION
## Summary
- collapse parent sections on the internal event page with expandable headers similar to the public view
- hide verification controls for non-admin users and keep action buttons in sync with the event status
- allow the close button to toggle between closing and reopening an event while updating the status badge

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e4cc6885fc8331bea2dec350557e31